### PR TITLE
fix: Extend supported IntelliJ version to 999 (temporary compatibility fix)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("231.8109.175")  // Match this to the actual IntelliJ version
-        untilBuild.set("243.*")
+        untilBuild.set("999.*")
     }
 
     signPlugin {


### PR DESCRIPTION
**Description:**

Hi! I noticed the plugin wasn't working in newer versions of IntelliJ (community version), even though it still works fine.

To unblock this, I've temporarily extended the supported version to `999.*` by updating the `untilBuild` property in the `build.gradle.kts` file. I didn't make any code changes. This is just a quick compatibility fix so the plugin doesn't get rejected by the IDE.

I'm aware this isn't a long-term solution, but it should help for now.

Thanks!

P.S. Oh, and the plugin is amazing :smiley: 

**Commits:**

- fix: Update 'untilBuild' property in build.gradle.kts.